### PR TITLE
Add CRUD for user profiles and activities

### DIFF
--- a/src/main/java/com/example/aihealthmanagement/controller/UserActivityController.java
+++ b/src/main/java/com/example/aihealthmanagement/controller/UserActivityController.java
@@ -1,0 +1,93 @@
+package com.example.aihealthmanagement.controller;
+
+import com.example.aihealthmanagement.common.ServiceException;
+import com.example.aihealthmanagement.common.ServiceResponse;
+import com.example.aihealthmanagement.dto.UserActivityDto;
+import com.example.aihealthmanagement.entity.UserActivity;
+import com.example.aihealthmanagement.security.CustomUserDetails;
+import com.example.aihealthmanagement.service.UserActivityService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/user-activities")
+public class UserActivityController {
+
+    @Autowired
+    private UserActivityService userActivityService;
+
+    private Long getCurrentUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !(auth.getPrincipal() instanceof CustomUserDetails)) {
+            throw new ServiceException(401, "User not authenticated");
+        }
+        return ((CustomUserDetails) auth.getPrincipal()).getId();
+    }
+
+    @GetMapping
+    public ServiceResponse<List<UserActivity>> list() {
+        Long userId = getCurrentUserId();
+        List<UserActivity> activities = userActivityService.listByUserId(userId);
+        return ServiceResponse.success(activities);
+    }
+
+    @GetMapping("/{id}")
+    public ServiceResponse<UserActivity> get(@PathVariable Long id) {
+        UserActivity activity = userActivityService.getById(id);
+        if (activity == null) {
+            throw new ServiceException(404, "Activity not found");
+        }
+        return ServiceResponse.success(activity);
+    }
+
+    @PostMapping
+    public ServiceResponse<?> create(@RequestBody UserActivityDto.ActivityRequest request) {
+        Long userId = getCurrentUserId();
+        UserActivity activity = UserActivity.builder()
+                .userId(userId)
+                .height(request.getHeight())
+                .weight(request.getWeight())
+                .bmi(request.getBmi())
+                .activityDate(request.getActivityDate())
+                .duration(request.getDuration())
+                .exerciseType(request.getExerciseType())
+                .steps(request.getSteps())
+                .calories(request.getCalories())
+                .maxHeartRate(request.getMaxHeartRate())
+                .minHeartRate(request.getMinHeartRate())
+                .build();
+        userActivityService.create(activity);
+        return ServiceResponse.success("Created", null);
+    }
+
+    @PutMapping("/{id}")
+    public ServiceResponse<?> update(@PathVariable Long id, @RequestBody UserActivityDto.ActivityRequest request) {
+        Long userId = getCurrentUserId();
+        UserActivity activity = UserActivity.builder()
+                .id(id)
+                .userId(userId)
+                .height(request.getHeight())
+                .weight(request.getWeight())
+                .bmi(request.getBmi())
+                .activityDate(request.getActivityDate())
+                .duration(request.getDuration())
+                .exerciseType(request.getExerciseType())
+                .steps(request.getSteps())
+                .calories(request.getCalories())
+                .maxHeartRate(request.getMaxHeartRate())
+                .minHeartRate(request.getMinHeartRate())
+                .build();
+        userActivityService.update(activity);
+        return ServiceResponse.success("Updated", null);
+    }
+
+    @DeleteMapping("/{id}")
+    public ServiceResponse<?> delete(@PathVariable Long id) {
+        userActivityService.delete(id);
+        return ServiceResponse.success("Deleted", null);
+    }
+}

--- a/src/main/java/com/example/aihealthmanagement/controller/UserProfileController.java
+++ b/src/main/java/com/example/aihealthmanagement/controller/UserProfileController.java
@@ -1,0 +1,77 @@
+package com.example.aihealthmanagement.controller;
+
+import com.example.aihealthmanagement.common.ServiceException;
+import com.example.aihealthmanagement.common.ServiceResponse;
+import com.example.aihealthmanagement.dto.UserProfileDto;
+import com.example.aihealthmanagement.entity.UserProfile;
+import com.example.aihealthmanagement.security.CustomUserDetails;
+import com.example.aihealthmanagement.service.UserProfileService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/user-profile")
+public class UserProfileController {
+
+    @Autowired
+    private UserProfileService userProfileService;
+
+    private Long getCurrentUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !(auth.getPrincipal() instanceof CustomUserDetails)) {
+            throw new ServiceException(401, "User not authenticated");
+        }
+        return ((CustomUserDetails) auth.getPrincipal()).getId();
+    }
+
+    @GetMapping
+    public ServiceResponse<UserProfile> getProfile() {
+        Long userId = getCurrentUserId();
+        UserProfile profile = userProfileService.getByUserId(userId);
+        if (profile == null) {
+            throw new ServiceException(404, "Profile not found");
+        }
+        return ServiceResponse.success(profile);
+    }
+
+    @PostMapping
+    public ServiceResponse<?> createProfile(@RequestBody UserProfileDto.ProfileRequest request) {
+        Long userId = getCurrentUserId();
+        UserProfile profile = UserProfile.builder()
+                .userId(userId)
+                .lastName(request.getLastName())
+                .firstName(request.getFirstName())
+                .age(request.getAge())
+                .occupation(request.getOccupation())
+                .gender(request.getGender())
+                .favoriteSport(request.getFavoriteSport())
+                .build();
+        userProfileService.create(profile);
+        return ServiceResponse.success("Created", null);
+    }
+
+    @PutMapping
+    public ServiceResponse<?> updateProfile(@RequestBody UserProfileDto.ProfileRequest request) {
+        Long userId = getCurrentUserId();
+        UserProfile profile = UserProfile.builder()
+                .userId(userId)
+                .lastName(request.getLastName())
+                .firstName(request.getFirstName())
+                .age(request.getAge())
+                .occupation(request.getOccupation())
+                .gender(request.getGender())
+                .favoriteSport(request.getFavoriteSport())
+                .build();
+        userProfileService.update(profile);
+        return ServiceResponse.success("Updated", null);
+    }
+
+    @DeleteMapping
+    public ServiceResponse<?> deleteProfile() {
+        Long userId = getCurrentUserId();
+        userProfileService.deleteByUserId(userId);
+        return ServiceResponse.success("Deleted", null);
+    }
+}

--- a/src/main/java/com/example/aihealthmanagement/dto/UserActivityDto.java
+++ b/src/main/java/com/example/aihealthmanagement/dto/UserActivityDto.java
@@ -1,0 +1,37 @@
+package com.example.aihealthmanagement.dto;
+
+import lombok.Data;
+
+import java.time.LocalDate;
+
+public class UserActivityDto {
+    @Data
+    public static class ActivityRequest {
+        private Double height;
+        private Double weight;
+        private Double bmi;
+        private LocalDate activityDate;
+        private Integer duration;
+        private String exerciseType;
+        private Integer steps;
+        private Integer calories;
+        private Integer maxHeartRate;
+        private Integer minHeartRate;
+    }
+
+    @Data
+    public static class ActivityResponse {
+        private Long id;
+        private Long userId;
+        private Double height;
+        private Double weight;
+        private Double bmi;
+        private LocalDate activityDate;
+        private Integer duration;
+        private String exerciseType;
+        private Integer steps;
+        private Integer calories;
+        private Integer maxHeartRate;
+        private Integer minHeartRate;
+    }
+}

--- a/src/main/java/com/example/aihealthmanagement/dto/UserProfileDto.java
+++ b/src/main/java/com/example/aihealthmanagement/dto/UserProfileDto.java
@@ -1,0 +1,27 @@
+package com.example.aihealthmanagement.dto;
+
+import lombok.Data;
+
+public class UserProfileDto {
+    @Data
+    public static class ProfileRequest {
+        private String lastName;
+        private String firstName;
+        private Integer age;
+        private String occupation;
+        private String gender;
+        private String favoriteSport;
+    }
+
+    @Data
+    public static class ProfileResponse {
+        private Long id;
+        private Long userId;
+        private String lastName;
+        private String firstName;
+        private Integer age;
+        private String occupation;
+        private String gender;
+        private String favoriteSport;
+    }
+}

--- a/src/main/java/com/example/aihealthmanagement/entity/UserActivity.java
+++ b/src/main/java/com/example/aihealthmanagement/entity/UserActivity.java
@@ -1,0 +1,27 @@
+package com.example.aihealthmanagement.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserActivity {
+    private Long id;
+    private Long userId;
+    private Double height;
+    private Double weight;
+    private Double bmi;
+    private LocalDate activityDate;
+    private Integer duration;
+    private String exerciseType;
+    private Integer steps;
+    private Integer calories;
+    private Integer maxHeartRate;
+    private Integer minHeartRate;
+}

--- a/src/main/java/com/example/aihealthmanagement/entity/UserProfile.java
+++ b/src/main/java/com/example/aihealthmanagement/entity/UserProfile.java
@@ -1,0 +1,21 @@
+package com.example.aihealthmanagement.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProfile {
+    private Long id;
+    private Long userId;
+    private String lastName;
+    private String firstName;
+    private Integer age;
+    private String occupation;
+    private String gender;
+    private String favoriteSport;
+}

--- a/src/main/java/com/example/aihealthmanagement/repository/UserActivityRepository.java
+++ b/src/main/java/com/example/aihealthmanagement/repository/UserActivityRepository.java
@@ -1,0 +1,26 @@
+package com.example.aihealthmanagement.repository;
+
+import com.example.aihealthmanagement.entity.UserActivity;
+import org.apache.ibatis.annotations.*;
+
+import java.util.List;
+
+@Mapper
+public interface UserActivityRepository {
+    @Select("SELECT * FROM user_activity WHERE user_id = #{userId}")
+    List<UserActivity> findByUserId(@Param("userId") Long userId);
+
+    @Select("SELECT * FROM user_activity WHERE id = #{id}")
+    UserActivity findById(@Param("id") Long id);
+
+    @Insert("INSERT INTO user_activity(user_id, height, weight, bmi, activity_date, duration, exercise_type, steps, calories, max_heart_rate, min_heart_rate) " +
+            "VALUES(#{userId}, #{height}, #{weight}, #{bmi}, #{activityDate}, #{duration}, #{exerciseType}, #{steps}, #{calories}, #{maxHeartRate}, #{minHeartRate})")
+    @Options(useGeneratedKeys = true, keyProperty = "id")
+    int insert(UserActivity activity);
+
+    @Update("UPDATE user_activity SET height=#{height}, weight=#{weight}, bmi=#{bmi}, activity_date=#{activityDate}, duration=#{duration}, exercise_type=#{exerciseType}, steps=#{steps}, calories=#{calories}, max_heart_rate=#{maxHeartRate}, min_heart_rate=#{minHeartRate} WHERE id=#{id}")
+    int update(UserActivity activity);
+
+    @Delete("DELETE FROM user_activity WHERE id = #{id}")
+    int delete(@Param("id") Long id);
+}

--- a/src/main/java/com/example/aihealthmanagement/repository/UserProfileRepository.java
+++ b/src/main/java/com/example/aihealthmanagement/repository/UserProfileRepository.java
@@ -1,0 +1,21 @@
+package com.example.aihealthmanagement.repository;
+
+import com.example.aihealthmanagement.entity.UserProfile;
+import org.apache.ibatis.annotations.*;
+
+@Mapper
+public interface UserProfileRepository {
+    @Select("SELECT * FROM user_profile WHERE user_id = #{userId}")
+    UserProfile findByUserId(@Param("userId") Long userId);
+
+    @Insert("INSERT INTO user_profile(user_id, last_name, first_name, age, occupation, gender, favorite_sport) " +
+            "VALUES(#{userId}, #{lastName}, #{firstName}, #{age}, #{occupation}, #{gender}, #{favoriteSport})")
+    @Options(useGeneratedKeys = true, keyProperty = "id")
+    int insert(UserProfile profile);
+
+    @Update("UPDATE user_profile SET last_name=#{lastName}, first_name=#{firstName}, age=#{age}, occupation=#{occupation}, gender=#{gender}, favorite_sport=#{favoriteSport} WHERE user_id=#{userId}")
+    int update(UserProfile profile);
+
+    @Delete("DELETE FROM user_profile WHERE user_id = #{userId}")
+    int deleteByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/com/example/aihealthmanagement/service/UserActivityService.java
+++ b/src/main/java/com/example/aihealthmanagement/service/UserActivityService.java
@@ -1,0 +1,13 @@
+package com.example.aihealthmanagement.service;
+
+import com.example.aihealthmanagement.entity.UserActivity;
+
+import java.util.List;
+
+public interface UserActivityService {
+    List<UserActivity> listByUserId(Long userId);
+    UserActivity getById(Long id);
+    void create(UserActivity activity);
+    void update(UserActivity activity);
+    void delete(Long id);
+}

--- a/src/main/java/com/example/aihealthmanagement/service/UserProfileService.java
+++ b/src/main/java/com/example/aihealthmanagement/service/UserProfileService.java
@@ -1,0 +1,10 @@
+package com.example.aihealthmanagement.service;
+
+import com.example.aihealthmanagement.entity.UserProfile;
+
+public interface UserProfileService {
+    UserProfile getByUserId(Long userId);
+    void create(UserProfile profile);
+    void update(UserProfile profile);
+    void deleteByUserId(Long userId);
+}

--- a/src/main/java/com/example/aihealthmanagement/service/impl/UserActivityServiceImpl.java
+++ b/src/main/java/com/example/aihealthmanagement/service/impl/UserActivityServiceImpl.java
@@ -1,0 +1,49 @@
+package com.example.aihealthmanagement.service.impl;
+
+import com.example.aihealthmanagement.common.ServiceException;
+import com.example.aihealthmanagement.entity.UserActivity;
+import com.example.aihealthmanagement.repository.UserActivityRepository;
+import com.example.aihealthmanagement.service.UserActivityService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class UserActivityServiceImpl implements UserActivityService {
+
+    private final UserActivityRepository repository;
+
+    @Autowired
+    public UserActivityServiceImpl(UserActivityRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public List<UserActivity> listByUserId(Long userId) {
+        return repository.findByUserId(userId);
+    }
+
+    @Override
+    public UserActivity getById(Long id) {
+        return repository.findById(id);
+    }
+
+    @Override
+    public void create(UserActivity activity) {
+        repository.insert(activity);
+    }
+
+    @Override
+    public void update(UserActivity activity) {
+        if (repository.findById(activity.getId()) == null) {
+            throw new ServiceException(404, "Activity not found");
+        }
+        repository.update(activity);
+    }
+
+    @Override
+    public void delete(Long id) {
+        repository.delete(id);
+    }
+}

--- a/src/main/java/com/example/aihealthmanagement/service/impl/UserProfileServiceImpl.java
+++ b/src/main/java/com/example/aihealthmanagement/service/impl/UserProfileServiceImpl.java
@@ -1,0 +1,45 @@
+package com.example.aihealthmanagement.service.impl;
+
+import com.example.aihealthmanagement.common.ServiceException;
+import com.example.aihealthmanagement.entity.UserProfile;
+import com.example.aihealthmanagement.repository.UserProfileRepository;
+import com.example.aihealthmanagement.service.UserProfileService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserProfileServiceImpl implements UserProfileService {
+
+    private final UserProfileRepository repository;
+
+    @Autowired
+    public UserProfileServiceImpl(UserProfileRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public UserProfile getByUserId(Long userId) {
+        return repository.findByUserId(userId);
+    }
+
+    @Override
+    public void create(UserProfile profile) {
+        if (repository.findByUserId(profile.getUserId()) != null) {
+            throw new ServiceException(400, "Profile already exists");
+        }
+        repository.insert(profile);
+    }
+
+    @Override
+    public void update(UserProfile profile) {
+        if (repository.findByUserId(profile.getUserId()) == null) {
+            throw new ServiceException(404, "Profile not found");
+        }
+        repository.update(profile);
+    }
+
+    @Override
+    public void deleteByUserId(Long userId) {
+        repository.deleteByUserId(userId);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,5 @@ spring.datasource.url=jdbc:mysql://localhost:3306/ai_health_db?useSSL=false&char
 spring.datasource.username=root
 spring.datasource.password=
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+# Enable underscore to camelCase mapping for MyBatis
+mybatis.configuration.map-underscore-to-camel-case=true


### PR DESCRIPTION
## Summary
- add entities for user_profile and user_activity tables
- implement repositories using MyBatis annotations
- create services and service implementations
- add DTOs for requests
- expose REST controllers for profile and activity management

## Testing
- `./mvnw -q test` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6845625f1914833394bff6cba5bc8eed