### PR TITLE
Add dietary record and food item CRUD

### DIFF
--- a/src/main/java/com/example/aihealthmanagement/controller/DietaryRecordController.java
+++ b/src/main/java/com/example/aihealthmanagement/controller/DietaryRecordController.java
@@ -1,0 +1,83 @@
+package com.example.aihealthmanagement.controller;
+
+import com.example.aihealthmanagement.common.ServiceException;
+import com.example.aihealthmanagement.common.ServiceResponse;
+import com.example.aihealthmanagement.dto.DietaryRecordDto;
+import com.example.aihealthmanagement.entity.DietaryRecord;
+import com.example.aihealthmanagement.security.CustomUserDetails;
+import com.example.aihealthmanagement.service.DietaryRecordService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/dietary-records")
+public class DietaryRecordController {
+
+    @Autowired
+    private DietaryRecordService dietaryRecordService;
+
+    private Long getCurrentUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !(auth.getPrincipal() instanceof CustomUserDetails)) {
+            throw new ServiceException(401, "User not authenticated");
+        }
+        return ((CustomUserDetails) auth.getPrincipal()).getId();
+    }
+
+    @GetMapping
+    public ServiceResponse<List<DietaryRecord>> list() {
+        Long userId = getCurrentUserId();
+        List<DietaryRecord> records = dietaryRecordService.listByUserId(userId);
+        return ServiceResponse.success(records);
+    }
+
+    @GetMapping("/{id}")
+    public ServiceResponse<DietaryRecord> get(@PathVariable Long id) {
+        DietaryRecord record = dietaryRecordService.getById(id);
+        if (record == null) {
+            throw new ServiceException(404, "Record not found");
+        }
+        return ServiceResponse.success(record);
+    }
+
+    @PostMapping
+    public ServiceResponse<?> create(@RequestBody DietaryRecordDto.RecordRequest request) {
+        Long userId = getCurrentUserId();
+        DietaryRecord record = DietaryRecord.builder()
+                .userId(userId)
+                .recordDate(request.getRecordDate())
+                .recordTime(request.getRecordTime())
+                .mealType(request.getMealType())
+                .notes(request.getNotes())
+                .totalCalories(request.getTotalCalories())
+                .build();
+        dietaryRecordService.create(record);
+        return ServiceResponse.success("Created", null);
+    }
+
+    @PutMapping("/{id}")
+    public ServiceResponse<?> update(@PathVariable Long id, @RequestBody DietaryRecordDto.RecordRequest request) {
+        Long userId = getCurrentUserId();
+        DietaryRecord record = DietaryRecord.builder()
+                .id(id)
+                .userId(userId)
+                .recordDate(request.getRecordDate())
+                .recordTime(request.getRecordTime())
+                .mealType(request.getMealType())
+                .notes(request.getNotes())
+                .totalCalories(request.getTotalCalories())
+                .build();
+        dietaryRecordService.update(record);
+        return ServiceResponse.success("Updated", null);
+    }
+
+    @DeleteMapping("/{id}")
+    public ServiceResponse<?> delete(@PathVariable Long id) {
+        dietaryRecordService.delete(id);
+        return ServiceResponse.success("Deleted", null);
+    }
+}

--- a/src/main/java/com/example/aihealthmanagement/controller/FoodItemController.java
+++ b/src/main/java/com/example/aihealthmanagement/controller/FoodItemController.java
@@ -1,0 +1,69 @@
+package com.example.aihealthmanagement.controller;
+
+import com.example.aihealthmanagement.common.ServiceException;
+import com.example.aihealthmanagement.common.ServiceResponse;
+import com.example.aihealthmanagement.dto.FoodItemDto;
+import com.example.aihealthmanagement.entity.FoodItem;
+import com.example.aihealthmanagement.service.FoodItemService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/food-items")
+public class FoodItemController {
+
+    @Autowired
+    private FoodItemService foodItemService;
+
+    @GetMapping
+    public ServiceResponse<List<FoodItem>> list(@RequestParam Long recordId) {
+        List<FoodItem> items = foodItemService.listByRecordId(recordId);
+        return ServiceResponse.success(items);
+    }
+
+    @GetMapping("/{id}")
+    public ServiceResponse<FoodItem> get(@PathVariable Long id) {
+        FoodItem item = foodItemService.getById(id);
+        if (item == null) {
+            throw new ServiceException(404, "Food item not found");
+        }
+        return ServiceResponse.success(item);
+    }
+
+    @PostMapping
+    public ServiceResponse<?> create(@RequestBody FoodItemDto.ItemRequest request) {
+        FoodItem item = FoodItem.builder()
+                .dietaryRecordId(request.getDietaryRecordId())
+                .name(request.getName())
+                .category(request.getCategory())
+                .quantity(request.getQuantity())
+                .unit(request.getUnit())
+                .calories(request.getCalories())
+                .build();
+        foodItemService.create(item);
+        return ServiceResponse.success("Created", null);
+    }
+
+    @PutMapping("/{id}")
+    public ServiceResponse<?> update(@PathVariable Long id, @RequestBody FoodItemDto.ItemRequest request) {
+        FoodItem item = FoodItem.builder()
+                .id(id)
+                .dietaryRecordId(request.getDietaryRecordId())
+                .name(request.getName())
+                .category(request.getCategory())
+                .quantity(request.getQuantity())
+                .unit(request.getUnit())
+                .calories(request.getCalories())
+                .build();
+        foodItemService.update(item);
+        return ServiceResponse.success("Updated", null);
+    }
+
+    @DeleteMapping("/{id}")
+    public ServiceResponse<?> delete(@PathVariable Long id) {
+        foodItemService.delete(id);
+        return ServiceResponse.success("Deleted", null);
+    }
+}

--- a/src/main/java/com/example/aihealthmanagement/dto/DietaryRecordDto.java
+++ b/src/main/java/com/example/aihealthmanagement/dto/DietaryRecordDto.java
@@ -1,0 +1,28 @@
+package com.example.aihealthmanagement.dto;
+
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public class DietaryRecordDto {
+    @Data
+    public static class RecordRequest {
+        private LocalDate recordDate;
+        private LocalTime recordTime;
+        private String mealType;
+        private String notes;
+        private Integer totalCalories;
+    }
+
+    @Data
+    public static class RecordResponse {
+        private Long id;
+        private Long userId;
+        private LocalDate recordDate;
+        private LocalTime recordTime;
+        private String mealType;
+        private String notes;
+        private Integer totalCalories;
+    }
+}

--- a/src/main/java/com/example/aihealthmanagement/dto/FoodItemDto.java
+++ b/src/main/java/com/example/aihealthmanagement/dto/FoodItemDto.java
@@ -1,0 +1,26 @@
+package com.example.aihealthmanagement.dto;
+
+import lombok.Data;
+
+public class FoodItemDto {
+    @Data
+    public static class ItemRequest {
+        private Long dietaryRecordId;
+        private String name;
+        private String category;
+        private Double quantity;
+        private String unit;
+        private Integer calories;
+    }
+
+    @Data
+    public static class ItemResponse {
+        private Long id;
+        private Long dietaryRecordId;
+        private String name;
+        private String category;
+        private Double quantity;
+        private String unit;
+        private Integer calories;
+    }
+}

--- a/src/main/java/com/example/aihealthmanagement/entity/DietaryRecord.java
+++ b/src/main/java/com/example/aihealthmanagement/entity/DietaryRecord.java
@@ -1,0 +1,25 @@
+package com.example.aihealthmanagement.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DietaryRecord {
+    private Long id;
+    private Long userId;
+    private LocalDate recordDate;
+    private LocalTime recordTime;
+    private String mealType;
+    private String notes;
+    private Integer totalCalories;
+    private LocalDateTime createTime;
+}

--- a/src/main/java/com/example/aihealthmanagement/entity/FoodItem.java
+++ b/src/main/java/com/example/aihealthmanagement/entity/FoodItem.java
@@ -1,0 +1,23 @@
+package com.example.aihealthmanagement.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FoodItem {
+    private Long id;
+    private Long dietaryRecordId;
+    private String name;
+    private String category;
+    private Double quantity;
+    private String unit;
+    private Integer calories;
+    private LocalDateTime createTime;
+}

--- a/src/main/java/com/example/aihealthmanagement/repository/DietaryRecordRepository.java
+++ b/src/main/java/com/example/aihealthmanagement/repository/DietaryRecordRepository.java
@@ -1,0 +1,26 @@
+package com.example.aihealthmanagement.repository;
+
+import com.example.aihealthmanagement.entity.DietaryRecord;
+import org.apache.ibatis.annotations.*;
+
+import java.util.List;
+
+@Mapper
+public interface DietaryRecordRepository {
+    @Select("SELECT * FROM dietary_record WHERE user_id = #{userId}")
+    List<DietaryRecord> findByUserId(@Param("userId") Long userId);
+
+    @Select("SELECT * FROM dietary_record WHERE id = #{id}")
+    DietaryRecord findById(@Param("id") Long id);
+
+    @Insert("INSERT INTO dietary_record(user_id, record_date, record_time, meal_type, notes, total_calories, create_time) " +
+            "VALUES(#{userId}, #{recordDate}, #{recordTime}, #{mealType}, #{notes}, #{totalCalories}, #{createTime})")
+    @Options(useGeneratedKeys = true, keyProperty = "id")
+    int insert(DietaryRecord record);
+
+    @Update("UPDATE dietary_record SET record_date=#{recordDate}, record_time=#{recordTime}, meal_type=#{mealType}, notes=#{notes}, total_calories=#{totalCalories} WHERE id=#{id}")
+    int update(DietaryRecord record);
+
+    @Delete("DELETE FROM dietary_record WHERE id = #{id}")
+    int delete(@Param("id") Long id);
+}

--- a/src/main/java/com/example/aihealthmanagement/repository/FoodItemRepository.java
+++ b/src/main/java/com/example/aihealthmanagement/repository/FoodItemRepository.java
@@ -1,0 +1,26 @@
+package com.example.aihealthmanagement.repository;
+
+import com.example.aihealthmanagement.entity.FoodItem;
+import org.apache.ibatis.annotations.*;
+
+import java.util.List;
+
+@Mapper
+public interface FoodItemRepository {
+    @Select("SELECT * FROM food_item WHERE dietary_record_id = #{recordId}")
+    List<FoodItem> findByRecordId(@Param("recordId") Long recordId);
+
+    @Select("SELECT * FROM food_item WHERE id = #{id}")
+    FoodItem findById(@Param("id") Long id);
+
+    @Insert("INSERT INTO food_item(dietary_record_id, name, category, quantity, unit, calories, create_time) " +
+            "VALUES(#{dietaryRecordId}, #{name}, #{category}, #{quantity}, #{unit}, #{calories}, #{createTime})")
+    @Options(useGeneratedKeys = true, keyProperty = "id")
+    int insert(FoodItem item);
+
+    @Update("UPDATE food_item SET name=#{name}, category=#{category}, quantity=#{quantity}, unit=#{unit}, calories=#{calories} WHERE id=#{id}")
+    int update(FoodItem item);
+
+    @Delete("DELETE FROM food_item WHERE id = #{id}")
+    int delete(@Param("id") Long id);
+}

--- a/src/main/java/com/example/aihealthmanagement/service/DietaryRecordService.java
+++ b/src/main/java/com/example/aihealthmanagement/service/DietaryRecordService.java
@@ -1,0 +1,13 @@
+package com.example.aihealthmanagement.service;
+
+import com.example.aihealthmanagement.entity.DietaryRecord;
+
+import java.util.List;
+
+public interface DietaryRecordService {
+    List<DietaryRecord> listByUserId(Long userId);
+    DietaryRecord getById(Long id);
+    void create(DietaryRecord record);
+    void update(DietaryRecord record);
+    void delete(Long id);
+}

--- a/src/main/java/com/example/aihealthmanagement/service/FoodItemService.java
+++ b/src/main/java/com/example/aihealthmanagement/service/FoodItemService.java
@@ -1,0 +1,13 @@
+package com.example.aihealthmanagement.service;
+
+import com.example.aihealthmanagement.entity.FoodItem;
+
+import java.util.List;
+
+public interface FoodItemService {
+    List<FoodItem> listByRecordId(Long recordId);
+    FoodItem getById(Long id);
+    void create(FoodItem item);
+    void update(FoodItem item);
+    void delete(Long id);
+}

--- a/src/main/java/com/example/aihealthmanagement/service/impl/DietaryRecordServiceImpl.java
+++ b/src/main/java/com/example/aihealthmanagement/service/impl/DietaryRecordServiceImpl.java
@@ -1,0 +1,51 @@
+package com.example.aihealthmanagement.service.impl;
+
+import com.example.aihealthmanagement.common.ServiceException;
+import com.example.aihealthmanagement.entity.DietaryRecord;
+import com.example.aihealthmanagement.repository.DietaryRecordRepository;
+import com.example.aihealthmanagement.service.DietaryRecordService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class DietaryRecordServiceImpl implements DietaryRecordService {
+
+    private final DietaryRecordRepository repository;
+
+    @Autowired
+    public DietaryRecordServiceImpl(DietaryRecordRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public List<DietaryRecord> listByUserId(Long userId) {
+        return repository.findByUserId(userId);
+    }
+
+    @Override
+    public DietaryRecord getById(Long id) {
+        return repository.findById(id);
+    }
+
+    @Override
+    public void create(DietaryRecord record) {
+        record.setCreateTime(LocalDateTime.now());
+        repository.insert(record);
+    }
+
+    @Override
+    public void update(DietaryRecord record) {
+        if (repository.findById(record.getId()) == null) {
+            throw new ServiceException(404, "Record not found");
+        }
+        repository.update(record);
+    }
+
+    @Override
+    public void delete(Long id) {
+        repository.delete(id);
+    }
+}

--- a/src/main/java/com/example/aihealthmanagement/service/impl/FoodItemServiceImpl.java
+++ b/src/main/java/com/example/aihealthmanagement/service/impl/FoodItemServiceImpl.java
@@ -1,0 +1,51 @@
+package com.example.aihealthmanagement.service.impl;
+
+import com.example.aihealthmanagement.common.ServiceException;
+import com.example.aihealthmanagement.entity.FoodItem;
+import com.example.aihealthmanagement.repository.FoodItemRepository;
+import com.example.aihealthmanagement.service.FoodItemService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class FoodItemServiceImpl implements FoodItemService {
+
+    private final FoodItemRepository repository;
+
+    @Autowired
+    public FoodItemServiceImpl(FoodItemRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public List<FoodItem> listByRecordId(Long recordId) {
+        return repository.findByRecordId(recordId);
+    }
+
+    @Override
+    public FoodItem getById(Long id) {
+        return repository.findById(id);
+    }
+
+    @Override
+    public void create(FoodItem item) {
+        item.setCreateTime(LocalDateTime.now());
+        repository.insert(item);
+    }
+
+    @Override
+    public void update(FoodItem item) {
+        if (repository.findById(item.getId()) == null) {
+            throw new ServiceException(404, "Food item not found");
+        }
+        repository.update(item);
+    }
+
+    @Override
+    public void delete(Long id) {
+        repository.delete(id);
+    }
+}


### PR DESCRIPTION
## Summary
- implement dietary record and food item entities
- add repositories, services, and controllers
- expose CRUD endpoints for dietary records and food items

## Testing
- `./mvnw -q test` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6857fc00b8bc833392892286f232cf91