### PR TITLE
Add UserMood CRUD

### DIFF
--- a/src/main/java/com/example/aihealthmanagement/controller/UserMoodController.java
+++ b/src/main/java/com/example/aihealthmanagement/controller/UserMoodController.java
@@ -1,0 +1,77 @@
+package com.example.aihealthmanagement.controller;
+
+import com.example.aihealthmanagement.common.ServiceException;
+import com.example.aihealthmanagement.common.ServiceResponse;
+import com.example.aihealthmanagement.dto.UserMoodDto;
+import com.example.aihealthmanagement.entity.UserMood;
+import com.example.aihealthmanagement.security.CustomUserDetails;
+import com.example.aihealthmanagement.service.UserMoodService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/user-moods")
+public class UserMoodController {
+
+    @Autowired
+    private UserMoodService userMoodService;
+
+    private Long getCurrentUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !(auth.getPrincipal() instanceof CustomUserDetails)) {
+            throw new ServiceException(401, "User not authenticated");
+        }
+        return ((CustomUserDetails) auth.getPrincipal()).getId();
+    }
+
+    @GetMapping
+    public ServiceResponse<List<UserMood>> list() {
+        Long userId = getCurrentUserId();
+        List<UserMood> moods = userMoodService.listByUserId(userId);
+        return ServiceResponse.success(moods);
+    }
+
+    @GetMapping("/{id}")
+    public ServiceResponse<UserMood> get(@PathVariable Long id) {
+        UserMood mood = userMoodService.getById(id);
+        if (mood == null) {
+            throw new ServiceException(404, "Mood not found");
+        }
+        return ServiceResponse.success(mood);
+    }
+
+    @PostMapping
+    public ServiceResponse<?> create(@RequestBody UserMoodDto.MoodRequest request) {
+        Long userId = getCurrentUserId();
+        UserMood mood = UserMood.builder()
+                .userId(userId)
+                .totalEvaluation(request.getTotalEvaluation())
+                .stressValue(request.getStressValue())
+                .build();
+        userMoodService.create(mood);
+        return ServiceResponse.success("Created", null);
+    }
+
+    @PutMapping("/{id}")
+    public ServiceResponse<?> update(@PathVariable Long id, @RequestBody UserMoodDto.MoodRequest request) {
+        Long userId = getCurrentUserId();
+        UserMood mood = UserMood.builder()
+                .id(id)
+                .userId(userId)
+                .totalEvaluation(request.getTotalEvaluation())
+                .stressValue(request.getStressValue())
+                .build();
+        userMoodService.update(mood);
+        return ServiceResponse.success("Updated", null);
+    }
+
+    @DeleteMapping("/{id}")
+    public ServiceResponse<?> delete(@PathVariable Long id) {
+        userMoodService.delete(id);
+        return ServiceResponse.success("Deleted", null);
+    }
+}

--- a/src/main/java/com/example/aihealthmanagement/dto/UserMoodDto.java
+++ b/src/main/java/com/example/aihealthmanagement/dto/UserMoodDto.java
@@ -1,0 +1,20 @@
+package com.example.aihealthmanagement.dto;
+
+import lombok.Data;
+
+public class UserMoodDto {
+    @Data
+    public static class MoodRequest {
+        private String totalEvaluation;
+        private Integer stressValue;
+    }
+
+    @Data
+    public static class MoodResponse {
+        private Long id;
+        private Long userId;
+        private String totalEvaluation;
+        private Integer stressValue;
+        private String todaysMood;
+    }
+}

--- a/src/main/java/com/example/aihealthmanagement/entity/UserMood.java
+++ b/src/main/java/com/example/aihealthmanagement/entity/UserMood.java
@@ -1,0 +1,21 @@
+package com.example.aihealthmanagement.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserMood {
+    private Long id;
+    private Long userId;
+    private String totalEvaluation;
+    private Integer stressValue;
+    private String todaysMood;
+    private LocalDateTime recordTime;
+}

--- a/src/main/java/com/example/aihealthmanagement/repository/UserMoodRepository.java
+++ b/src/main/java/com/example/aihealthmanagement/repository/UserMoodRepository.java
@@ -1,0 +1,26 @@
+package com.example.aihealthmanagement.repository;
+
+import com.example.aihealthmanagement.entity.UserMood;
+import org.apache.ibatis.annotations.*;
+
+import java.util.List;
+
+@Mapper
+public interface UserMoodRepository {
+    @Select("SELECT * FROM user_mood WHERE user_id = #{userId}")
+    List<UserMood> findByUserId(@Param("userId") Long userId);
+
+    @Select("SELECT * FROM user_mood WHERE id = #{id}")
+    UserMood findById(@Param("id") Long id);
+
+    @Insert("INSERT INTO user_mood(user_id, total_evaluation, stress_value, record_time) " +
+            "VALUES(#{userId}, #{totalEvaluation}, #{stressValue}, #{recordTime})")
+    @Options(useGeneratedKeys = true, keyProperty = "id")
+    int insert(UserMood mood);
+
+    @Update("UPDATE user_mood SET total_evaluation=#{totalEvaluation}, stress_value=#{stressValue} WHERE id=#{id}")
+    int update(UserMood mood);
+
+    @Delete("DELETE FROM user_mood WHERE id = #{id}")
+    int delete(@Param("id") Long id);
+}

--- a/src/main/java/com/example/aihealthmanagement/service/UserMoodService.java
+++ b/src/main/java/com/example/aihealthmanagement/service/UserMoodService.java
@@ -1,0 +1,13 @@
+package com.example.aihealthmanagement.service;
+
+import com.example.aihealthmanagement.entity.UserMood;
+
+import java.util.List;
+
+public interface UserMoodService {
+    List<UserMood> listByUserId(Long userId);
+    UserMood getById(Long id);
+    void create(UserMood mood);
+    void update(UserMood mood);
+    void delete(Long id);
+}

--- a/src/main/java/com/example/aihealthmanagement/service/impl/UserMoodServiceImpl.java
+++ b/src/main/java/com/example/aihealthmanagement/service/impl/UserMoodServiceImpl.java
@@ -1,0 +1,51 @@
+package com.example.aihealthmanagement.service.impl;
+
+import com.example.aihealthmanagement.common.ServiceException;
+import com.example.aihealthmanagement.entity.UserMood;
+import com.example.aihealthmanagement.repository.UserMoodRepository;
+import com.example.aihealthmanagement.service.UserMoodService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class UserMoodServiceImpl implements UserMoodService {
+
+    private final UserMoodRepository repository;
+
+    @Autowired
+    public UserMoodServiceImpl(UserMoodRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public List<UserMood> listByUserId(Long userId) {
+        return repository.findByUserId(userId);
+    }
+
+    @Override
+    public UserMood getById(Long id) {
+        return repository.findById(id);
+    }
+
+    @Override
+    public void create(UserMood mood) {
+        mood.setRecordTime(LocalDateTime.now());
+        repository.insert(mood);
+    }
+
+    @Override
+    public void update(UserMood mood) {
+        if (repository.findById(mood.getId()) == null) {
+            throw new ServiceException(404, "Mood not found");
+        }
+        repository.update(mood);
+    }
+
+    @Override
+    public void delete(Long id) {
+        repository.delete(id);
+    }
+}


### PR DESCRIPTION
## Summary
- add `UserMood` entity for tracking daily stress scores
- create MyBatis repository for `user_mood`
- implement `UserMoodService` and its service implementation
- expose CRUD endpoints through `UserMoodController`
- add DTO class for request/response data

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871403824fc8333ae8b854158b0d2ec